### PR TITLE
Add namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace("com.jhomlala.better_player")
     compileSdkVersion 31
 
     compileOptions {


### PR DESCRIPTION
Error occurs when trying to build app that depends on this package.